### PR TITLE
Convert policies to policy documents

### DIFF
--- a/terraform/groups.tf
+++ b/terraform/groups.tf
@@ -4,11 +4,11 @@ resource "aws_iam_group" "cross-account-access" {
 
 resource "aws_iam_group_policy_attachment" "cross-account-attach-self-manage" {
     group = "${aws_iam_group.cross-account-access.name}"
-    policy_arn = "${aws_iam_policy.self-manage-iam-user.arn}"
+    policy_arn = "${aws_iam_policy.self_manage_iam_user.arn}"
 }
 resource "aws_iam_group_policy_attachment" "cross-account-attach-assume-role" {
     group = "${aws_iam_group.cross-account-access.name}"
-    policy_arn = "${aws_iam_policy.assume-any-role.arn}"
+    policy_arn = "${aws_iam_policy.assume_any_role.arn}"
 }
 
 resource "aws_iam_group" "administrators" {

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -12,8 +12,8 @@ data "aws_iam_policy_document" "assume_any_role" {
     }
 }
 
-resource "aws_iam_policy" "assume-any-role" {
-    name = "assume-any-role"
+resource "aws_iam_policy" "assume_any_role" {
+    name = "assume_any_role"
     description = "Allows the user to call sts:AssumeRole on anything"
     policy = "${data.aws_iam_policy_document.assume_any_role.json}"
 }
@@ -91,8 +91,8 @@ data "aws_iam_policy_document" "self_manage_iam_user" {
     }
 }
 
-resource "aws_iam_policy" "self-manage-iam-user" {
-    name = "self-manage-iam-user"
+resource "aws_iam_policy" "self_manage_iam_user" {
+    name = "self_manage_iam_user"
     description = "Allows the user to manage their own credentials and list all users"
     policy = "${data.aws_iam_policy_document.self_manage_iam_user.json}"
 }

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -1,22 +1,21 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_policy_document" "assume_any_role" {
+    statement {
+        effect = "Allow"
+        actions = [
+            "sts:AssumeRole",
+        ]
+        resources = [
+            "*",
+        ]
+    }
+}
+
 resource "aws_iam_policy" "assume-any-role" {
     name = "assume-any-role"
     description = "Allows the user to call sts:AssumeRole on anything"
-    policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "sts:AssumeRole"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+    policy = "${data.aws_iam_policy_document.assume_any_role.json}"
 }
 
 resource "aws_iam_policy" "self-manage-iam-user" {

--- a/terraform/policies.tf
+++ b/terraform/policies.tf
@@ -18,72 +18,81 @@ resource "aws_iam_policy" "assume-any-role" {
     policy = "${data.aws_iam_policy_document.assume_any_role.json}"
 }
 
+data "aws_iam_policy_document" "self_manage_iam_user" {
+    statement {
+        effect = "Allow"
+        actions = [
+            "iam:*LoginProfile",
+            "iam:*AccessKey*",
+            "iam:*SSHPublicKey*"
+        ]
+        resources = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+        ]
+    }
+
+    statement {
+        effect = "Allow"
+        actions = [
+            "iam:ListAccount*",
+            "iam:GetAccountSummary",
+            "iam:GetAccountPasswordPolicy",
+            "iam:ListUsers"
+        ]
+        resources = [
+            "*",
+        ]
+    }
+
+    statement {
+        sid = "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice"
+        effect = "Allow"
+        actions = [
+            "iam:CreateVirtualMFADevice",
+            "iam:EnableMFADevice",
+            "iam:ResyncMFADevice",
+            "iam:DeleteVirtualMFADevice"
+        ]
+        resources = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
+        ]
+    }
+
+    statement = {
+        sid = "AllowUsersToDeactivateTheirOwnVirtualMFADevice"
+        effect = "Allow"
+        actions = [
+            "iam:DeactivateMFADevice"
+        ]
+        resources = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
+        ]
+        condition {
+            test = "Bool"
+            variable = "aws:MultiFactorAuthPresent"
+            values = [
+                "true",
+            ]
+        }
+    }
+
+    statement {
+        sid = "AllowUsersToListMFADevicesandUsersForConsole"
+        effect = "Allow"
+        actions = [
+            "iam:ListMFADevices",
+            "iam:ListVirtualMFADevices"
+        ]
+        resources = [
+            "*",
+        ]
+    }
+}
+
 resource "aws_iam_policy" "self-manage-iam-user" {
     name = "self-manage-iam-user"
     description = "Allows the user to manage their own credentials and list all users"
-    policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:*LoginProfile",
-                "iam:*AccessKey*",
-                "iam:*SSHPublicKey*"
-            ],
-            "Resource": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:ListAccount*",
-                "iam:GetAccountSummary",
-                "iam:GetAccountPasswordPolicy",
-                "iam:ListUsers"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "AllowUsersToCreateEnableResyncDeleteTheirOwnVirtualMFADevice",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateVirtualMFADevice",
-                "iam:EnableMFADevice",
-                "iam:ResyncMFADevice",
-                "iam:DeleteVirtualMFADevice"
-            ],
-            "Resource": [
-                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
-                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
-            ]
-        },
-        {
-            "Sid": "AllowUsersToDeactivateTheirOwnVirtualMFADevice",
-            "Effect": "Allow",
-            "Action": [
-                "iam:DeactivateMFADevice"
-            ],
-            "Resource": [
-                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
-                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}"
-            ],
-            "Condition": {
-                "Bool": {
-                    "aws:MultiFactorAuthPresent": true
-                }
-            }
-        },
-        {
-            "Sid": "AllowUsersToListMFADevicesandUsersForConsole",
-            "Effect": "Allow",
-            "Action": [
-                "iam:ListMFADevices",
-                "iam:ListVirtualMFADevices"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
+    policy = "${data.aws_iam_policy_document.self_manage_iam_user.json}"
 }


### PR DESCRIPTION
This makes the policies slightly easier to read, and less prone to JSON syntax errors. We can't use hyphens in the policy document names because they aren't valid in the interpolation, so use underscores instead, on both the policy documents and policies for consistency.

`effect` defaults to `"Allow"`, but I've included it in the statements anyway to avoid doubt.